### PR TITLE
Ability to use a custom color palette

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -265,8 +265,19 @@ export default class ColoredTagsPlugin extends Plugin {
 		}
 	}
 
+	isValidHexColor(hexString) {
+		return /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/.test(hexString);
+	}
+
 	async loadSettings() {
 		const loadedData = await this.loadData();
+
+		if (loadedData && loadedData.customColors && loadedData.customColors.length) {
+			loadedData.customColors = loadedData.customColors.filter((color) => {
+				return this.isValidHexColor(color);
+			});
+		}
+
 		let needToSave = false;
 
 		if (loadedData && loadedData._version < 2) {


### PR DESCRIPTION
This pull request aims to implement a way for the user to manually edit the colors of the color palette used for coloring the tags.

A new input was created on the plugin's settings screen to receive the customized colors. The user should enter the hex code of the desired colors, separating each one with commas.

![image](https://github.com/pfrankov/obsidian-colored-tags/assets/52429925/f5738aba-8cb7-4d77-8733-0913404231ef)
