### PR TITLE
Color "tags" property pills in Bases views (closes #49)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -253,6 +253,7 @@ export default class ColoredTagsPlugin extends Plugin {
 			`a.tag.colored-tag-${tagLower}`,
 			`.cm-s-obsidian .cm-line span.cm-hashtag.colored-tag-${tagLower}`,
 			`.metadata-property[data-property-key="tags" i] .multi-select-pill.colored-tag-${tagLower}`,
+			`.bases-metadata-value[data-property-type="tags" i] .multi-select-pill.colored-tag-${tagLower}`,
 		];
 
 		if (tagFlat && !tagName.includes("/")) {
@@ -271,6 +272,7 @@ export default class ColoredTagsPlugin extends Plugin {
 		return tagLower
 			? [
 					`.metadata-property[data-property-key="tags" i] .multi-select-pill-remove-button.colored-tag-${tagLower}`,
+					`.bases-metadata-value[data-property-type="tags" i] .multi-select-pill-remove-button.colored-tag-${tagLower}`,
 				]
 			: [];
 	}

--- a/src/tag-appliers/BaseViewTagApplier.ts
+++ b/src/tag-appliers/BaseViewTagApplier.ts
@@ -1,15 +1,38 @@
 import { TagApplier, normalizeTagText } from "./TagApplier";
+import {
+	getMultiSelectPillName,
+	getMultiSelectPillTargets,
+} from "./multiSelectPill";
 
-const BASE_TAG_SELECTOR =
+// Bases renders `tags` property cells as multi-select pills (same widget as the
+// file properties panel) inside `.bases-metadata-value[data-property-type="tags"]`.
+const BASE_PILL_SELECTOR =
+	'.bases-metadata-value[data-property-type="tags" i] .multi-select-pill';
+
+// Fallback for anything that still renders tags as plain `a.tag` links.
+const BASE_TAG_LINK_SELECTOR =
 	'.bases-table a.tag, .bases-table-container a.tag, .value-list-container a.tag, a.tag[href^="#"]';
 
+const BASE_TAG_SELECTOR = `${BASE_PILL_SELECTOR}, ${BASE_TAG_LINK_SELECTOR}`;
+
+function isPill(el: HTMLElement): boolean {
+	return el.classList.contains("multi-select-pill");
+}
+
 export function getTagNameFromElement(el: HTMLElement): string | null {
-	return normalizeTagText(el.textContent);
+	return isPill(el)
+		? getMultiSelectPillName(el)
+		: normalizeTagText(el.textContent);
+}
+
+function getTagTargets(el: HTMLElement): HTMLElement[] {
+	return isPill(el) ? getMultiSelectPillTargets(el) : [el];
 }
 
 const singleUseApplier = new TagApplier({
 	selector: BASE_TAG_SELECTOR,
 	getTagText: getTagNameFromElement,
+	getTagTargets,
 });
 
 export function applyBaseTagClasses(target: ParentNode = document.body): void {
@@ -23,6 +46,7 @@ export class BaseViewTagApplier {
 		this.applier = new TagApplier({
 			selector: BASE_TAG_SELECTOR,
 			getTagText: getTagNameFromElement,
+			getTagTargets,
 		});
 	}
 

--- a/src/tag-appliers/PropertiesTagApplier.ts
+++ b/src/tag-appliers/PropertiesTagApplier.ts
@@ -1,26 +1,16 @@
-import { TagApplier, normalizeTagText } from "./TagApplier";
+import { TagApplier } from "./TagApplier";
+import {
+	getMultiSelectPillName,
+	getMultiSelectPillTargets,
+} from "./multiSelectPill";
 
 const PROPERTY_TAG_SELECTOR =
 	'.metadata-property[data-property-key="tags" i] .multi-select-pill';
 
-const getPropertyTagTargets = (pillEl: HTMLElement): HTMLElement[] => {
-	const removeButton = pillEl.querySelector<HTMLElement>(
-		".multi-select-pill-remove-button",
-	);
-	return removeButton ? [pillEl, removeButton] : [pillEl];
-};
-
-const getPropertyTagName = (pillEl: HTMLElement): string | null => {
-	const content = pillEl.querySelector<HTMLElement>(
-		".multi-select-pill-content",
-	);
-	return normalizeTagText(content?.textContent ?? pillEl.textContent);
-};
-
 const singleUseApplier = new TagApplier({
 	selector: PROPERTY_TAG_SELECTOR,
-	getTagText: getPropertyTagName,
-	getTagTargets: getPropertyTagTargets,
+	getTagText: getMultiSelectPillName,
+	getTagTargets: getMultiSelectPillTargets,
 });
 
 export function applyPropertiesTagClasses(
@@ -35,8 +25,8 @@ export class PropertiesTagApplier {
 	constructor() {
 		this.applier = new TagApplier({
 			selector: PROPERTY_TAG_SELECTOR,
-			getTagText: getPropertyTagName,
-			getTagTargets: getPropertyTagTargets,
+			getTagText: getMultiSelectPillName,
+			getTagTargets: getMultiSelectPillTargets,
 		});
 	}
 

--- a/src/tag-appliers/multiSelectPill.ts
+++ b/src/tag-appliers/multiSelectPill.ts
@@ -1,0 +1,15 @@
+import { normalizeTagText } from "./TagApplier";
+
+export function getMultiSelectPillTargets(pillEl: HTMLElement): HTMLElement[] {
+	const removeButton = pillEl.querySelector<HTMLElement>(
+		".multi-select-pill-remove-button",
+	);
+	return removeButton ? [pillEl, removeButton] : [pillEl];
+}
+
+export function getMultiSelectPillName(pillEl: HTMLElement): string | null {
+	const content = pillEl.querySelector<HTMLElement>(
+		".multi-select-pill-content",
+	);
+	return normalizeTagText(content?.textContent ?? pillEl.textContent);
+}

--- a/tests/BaseViewTagApplier.spec.ts
+++ b/tests/BaseViewTagApplier.spec.ts
@@ -5,6 +5,37 @@ import {
 	getTagNameFromElement,
 } from "../src/tag-appliers/BaseViewTagApplier";
 
+function createBasesTagsCell(...values: string[]): HTMLElement {
+	const cell = document.createElement("div");
+	cell.className =
+		"bases-table-cell bases-metadata-value metadata-property-value";
+	cell.setAttribute("data-property-type", "tags");
+
+	const container = document.createElement("div");
+	container.className = "multi-select-container";
+
+	for (const value of values) {
+		const pill = document.createElement("div");
+		pill.className = "multi-select-pill";
+
+		const content = document.createElement("div");
+		content.className = "multi-select-pill-content";
+		const span = document.createElement("span");
+		span.textContent = value;
+		content.appendChild(span);
+		pill.appendChild(content);
+
+		const remove = document.createElement("div");
+		remove.className = "multi-select-pill-remove-button";
+		pill.appendChild(remove);
+
+		container.appendChild(pill);
+	}
+
+	cell.appendChild(container);
+	return cell;
+}
+
 describe("getTagNameFromElement", () => {
 	it("normalizes tag text and strips hash", () => {
 		const el = document.createElement("a");
@@ -18,6 +49,13 @@ describe("getTagNameFromElement", () => {
 		el.textContent = "   ";
 
 		expect(getTagNameFromElement(el)).toBeNull();
+	});
+
+	it("reads the pill content for multi-select pills", () => {
+		const cell = createBasesTagsCell("First");
+		const pill = cell.querySelector<HTMLElement>(".multi-select-pill")!;
+
+		expect(getTagNameFromElement(pill)).toBe("first");
 	});
 });
 
@@ -97,6 +135,40 @@ describe("BaseViewTagApplier", () => {
 		expect(tag.classList.contains("colored-tag-instant")).toBe(true);
 
 		applier.stop();
+	});
+
+	it("colors multi-select pills inside a bases tags cell", () => {
+		const root = document.createElement("div");
+		const cell = createBasesTagsCell("First", "Second");
+		root.appendChild(cell);
+
+		applyBaseTagClasses(root);
+
+		const pills = cell.querySelectorAll<HTMLElement>(".multi-select-pill");
+		expect(pills[0].classList.contains("colored-tag-first")).toBe(true);
+		expect(pills[1].classList.contains("colored-tag-second")).toBe(true);
+
+		const removeButtons = cell.querySelectorAll<HTMLElement>(
+			".multi-select-pill-remove-button",
+		);
+		expect(removeButtons[0].classList.contains("colored-tag-first")).toBe(
+			true,
+		);
+		expect(removeButtons[1].classList.contains("colored-tag-second")).toBe(
+			true,
+		);
+	});
+
+	it("ignores multi-select pills outside a tags cell", () => {
+		const root = document.createElement("div");
+		const cell = createBasesTagsCell("First");
+		cell.setAttribute("data-property-type", "text");
+		root.appendChild(cell);
+
+		applyBaseTagClasses(root);
+
+		const pill = cell.querySelector<HTMLElement>(".multi-select-pill")!;
+		expect(pill.className.includes("colored-tag")).toBe(false);
 	});
 
 	it("adds classes to regular markdown tag links", () => {


### PR DESCRIPTION
## What

Colorizes the editable **`tags`** property column in Obsidian **Bases** (table and card views).

Closes #49.

Before:
<img width="1031" height="313" alt="image" src="https://github.com/user-attachments/assets/db7b8b4c-b1cc-4a62-9b6b-c692aad8de9f" />

After:
<img width="1138" height="333" alt="image" src="https://github.com/user-attachments/assets/e6eb1b80-03cc-4b8a-9645-35fda9e832d5" />


## Why it didn't work before

Bases renders the editable `tags` (`note.tags`) property as **multi-select pills** inside `.bases-metadata-value[data-property-type="tags"]`, *not* as `a.tag` links. Neither existing applier matched them:

- `BaseViewTagApplier` looked for `a.tag` (which only covers the read-only `file.tags` column).
- `PropertiesTagApplier` required the `.metadata-property[data-property-key="tags"]` wrapper, which Bases cells don't have.

So the `tags` column stayed uncolored while `file.tags` was already colored — which matches the report in #49.

## Changes

- **`BaseViewTagApplier`** now also matches the Bases tag-pill selector, reads the tag name from `.multi-select-pill-content`, and applies the `colored-tag-*` class to both the pill and its remove (×) button.
- Extracted the shared pill text/target helpers into a new `multiSelectPill` module, reused by both the Properties and Base appliers. `PropertiesTagApplier` behavior is unchanged.
- **`main.ts`** emits the matching CSS selectors for Bases tag pills (tag + remove button), scoped to `.bases-metadata-value[data-property-type="tags"]`.
- Tests cover the real Bases cell DOM, including a negative case (a non-`tags` cell must stay uncolored).

## Verification

- `npm run test:coverage` passes at 100% statements/branches/functions/lines (new `multiSelectPill.ts` and both appliers at 100%).
- Typecheck + lint clean.
- Verified live in Obsidian: the editable `tags` column pills are now colored consistently with `file.tags`.

Thank you for this nice plugin!